### PR TITLE
chore(deps): drop unused cookie + get-port-please

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@trivago/prettier-plugin-sort-imports": "catalog:",
     "@types/node": "^24.10.0",
     "@vitest/coverage-v8": "4.1.8",
-    "cookie": "catalog:",
     "eslint": "catalog:",
     "eslint-config-prettier": "catalog:",
     "eslint-plugin-prettier": "catalog:",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -36,7 +36,6 @@
     "LICENSE"
   ],
   "dependencies": {
-    "get-port-please": "catalog:",
     "globals": "^16.5.0",
     "lodash-es": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,9 +21,6 @@ catalogs:
     '@types/lodash-es':
       specifier: ^4.17.12
       version: 4.17.12
-    cookie:
-      specifier: ^1.0.0
-      version: 1.1.1
     eslint:
       specifier: ^10.0.2
       version: 10.4.1
@@ -33,9 +30,6 @@ catalogs:
     eslint-plugin-prettier:
       specifier: ^5.5.5
       version: 5.5.6
-    get-port-please:
-      specifier: ^3.2.0
-      version: 3.2.0
     jiti:
       specifier: ^2.6.1
       version: 2.7.0
@@ -83,9 +77,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.8
         version: 4.1.8(vitest@4.1.8)
-      cookie:
-        specifier: 'catalog:'
-        version: 1.1.1
       eslint:
         specifier: 'catalog:'
         version: 10.4.1(jiti@2.7.0)
@@ -220,9 +211,6 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      get-port-please:
-        specifier: 'catalog:'
-        version: 3.2.0
       globals:
         specifier: ^16.5.0
         version: 16.5.0
@@ -1860,9 +1848,6 @@ packages:
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-
-  get-port-please@3.2.0:
-    resolution: {integrity: sha512-I9QVvBw5U/hw3RmWpYKRumUeaDgxTPd401x364rLmWBJcOQ753eov1eTgzDqRG9bqFIfDc7gfzcQEWrUri3o1A==}
 
   git-hooks-list@4.2.1:
     resolution: {integrity: sha512-WNvqJjOxxs/8ZP9+DWdwWJ7cDsd60NHf39XnD82pDVrKO5q7xfPqpkK6hwEAmBa/ZSEE4IOoR75EzbbIuwGlMw==}
@@ -4194,8 +4179,6 @@ snapshots:
     optional: true
 
   get-caller-file@2.0.5: {}
-
-  get-port-please@3.2.0: {}
 
   git-hooks-list@4.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,11 +11,9 @@ catalog:
   "@eslint/js": ^10.0.1
   "@trivago/prettier-plugin-sort-imports": ^6.0.2
   "@types/lodash-es": ^4.17.12
-  cookie: ^1.0.0
   eslint: ^10.0.2
   eslint-config-prettier: ^10.1.8
   eslint-plugin-prettier: ^5.5.5
-  get-port-please: ^3.2.0
   jiti: ^2.6.1
   jsdom: ^29.0.0
   lodash-es: ^4.17.23


### PR DESCRIPTION
## Summary

Removes two dependencies that are imported nowhere in the workspace (verified across all three packages — `browser`, `configs`, `test`):

| Dep | Where | Why it's dead |
| --- | --- | --- |
| `cookie` | root `devDependencies` + catalog | no `cookie.parse` / `cookie.serialize` / import anywhere |
| `get-port-please` | `@a-novel-kit/nodelib-test` `dependencies` + catalog | imported by nothing; vestigial from the old `setup-env.sh` random-port era (those scripts are now deleted) |

Both were swept into the catalog by #360 and carried along unused since.

### Deliberately kept

- **`jsdom`** — it's the vitest test `environment` (`vitest.config.ts`), used at runtime by the test runner even though nothing imports it directly.
- **`minimumReleaseAgeExclude`** svelte / storybook / typescript-eslint entries — those ecosystems are still live deps of the `configs` package (shared eslint/prettier presets), so the Renovate exclusions are not stale.

## Breaking changes

None. `get-port-please` is removed from a published package's `dependencies`, but it was never imported or re-exported, so no consumer can be relying on it through this package.

## Test plan

- [x] `pnpm i` regenerates the lockfile (get-port-please fully gone, 0 refs)
- [x] `pnpm lint` exit 0
- [x] `pnpm build:config` + full `a-novel test --type=pnpm -y` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)