### PR TITLE
docs(readme): drop the codecov graph token from badge URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Shared Node.js libraries.
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/a-novel-kit/nodelib)
 
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/a-novel-kit/nodelib/main.yaml)
-[![codecov](https://codecov.io/gh/a-novel-kit/nodelib/graph/badge.svg?token=0APmxMlooh)](https://codecov.io/gh/a-novel-kit/nodelib)
+[![codecov](https://codecov.io/gh/a-novel-kit/nodelib/graph/badge.svg)](https://codecov.io/gh/a-novel-kit/nodelib)
 
-![Coverage graph](https://codecov.io/gh/a-novel-kit/nodelib/graphs/sunburst.svg?token=0APmxMlooh)
+![Coverage graph](https://codecov.io/gh/a-novel-kit/nodelib/graphs/sunburst.svg)
 
 ## Installation
 


### PR DESCRIPTION
Public-repo Codecov badges render without a token, so the graph token in the badge + sunburst URLs is unnecessary. Stripping it for cleaner, tokenless badges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)