### PR TITLE
fix(ci): prettier-format the codeql workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["actions","javascript-typescript"]
+        language: ["actions", "javascript-typescript"]
     steps:
       - uses: actions/checkout@v7
       - uses: github/codeql-action/init@v4


### PR DESCRIPTION
The CodeQL advanced-setup workflow was committed with a comma-without-space `language` array and no trailing newline, which fails `prettier --check` (the `lint-node` job) on master. This reformats it to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)