### PR TITLE
ci: add publish:patch for security-update auto-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint:typecheck:browser": "pnpm tsc --p ./packages/browser/tsconfig.json --noEmit",
     "lint:typecheck:configs": "pnpm tsc --p ./packages/configs/tsconfig.json --noEmit",
     "lint:typecheck:test": "pnpm tsc --p ./packages/test/tsconfig.json --noEmit",
+    "publish:patch": "pnpm version patch && git push --follow-tags",
     "test": "vitest run",
     "test:ci": "pnpm build:config && pnpm build:browser && pnpm test",
     "types:browser": "tsc --build packages/browser/tsconfig.build.json",


### PR DESCRIPTION
The scheduled `security-update` workflow fails with `[ERR_PNPM_NO_SCRIPT] Missing script: publish:patch`. `node-actions/security-update` calls `pnpm run publish:patch` to cut a patch release when the default branch has unreleased commits; the script was removed in the publish-CLI migration.

Restore it, matching jwt — bump the version, push the commit + tag so `release.yaml` fires (build + `pnpm publish`):

```
"publish:patch": "pnpm version patch && git push --follow-tags"
```

Note: only succeeds once the publish bot can push to the default branch — blocked today by the codecov ruleset (fixed in a-novel-kit/stack#81, applied per-repo via `a-novel repo update`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)