### PR TITLE
docs: standardize README + CONTRIBUTING, fill code-of-conduct contact

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[INSERT CONTACT METHOD].
+geoffroy.vincent@agorastoryverse.com.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to nodelib
+
+For platform-wide setup (Go, Node, Podman, the `a-novel` CLI) and the day-to-day commands, see the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md). This file documents what is specific to `nodelib`.
+
+## Repo layout
+
+`nodelib` is a [pnpm](https://pnpm.io) workspace. Every published package lives under `packages/*`, each exposing its source directly (no `src/` indirection) with a colocated `package.json`, `tsconfig.json`, and `vite.config.ts`:
+
+- `packages/browser` → `@a-novel-kit/nodelib-browser`
+- `packages/configs` → `@a-novel-kit/nodelib-config`
+- `packages/test` → `@a-novel-kit/nodelib-test`
+
+Shared dependency versions are pinned through the workspace catalog in `pnpm-workspace.yaml` (the `catalog:` entries in each `package.json`).
+
+## Working in the repo
+
+All commands run from the repo root:
+
+- `pnpm install` — install the workspace.
+- `pnpm build` — compile every package (Vite bundle + `tsc` type declarations) into its `dist/`.
+- `pnpm test` — run the [Vitest](https://vitest.dev) suite; tests are colocated as `*.test.ts` files next to their sources.
+- `pnpm lint` — run Prettier (style check), `tsc --noEmit` (type check), and ESLint.
+- `pnpm format` — apply Prettier across the workspace.
+
+CI runs `pnpm lint:ci` and `pnpm test:ci`, which build the config and browser packages first so the rest of the workspace can resolve them. Prettier is gated in CI, so run `pnpm format` before committing.
+
+## Publishing
+
+Packages are published to GitHub Packages under the `@a-novel-kit/` scope. The three packages share a single version, bumped together via `pnpm version` and released by pushing the resulting tag (`git push --follow-tags`); the release workflow builds and publishes from the tag.
+
+## The bar for additions
+
+`nodelib` is intentionally minimal — it holds only the cross-cutting glue that the frontends and tooling would otherwise copy between repos. Before adding to it, weigh the addition against this bar:
+
+- **A well-maintained library already does it?** Use that library directly; do not wrap it here.
+- **Only one project needs it?** Keep it in that project until a second one does.
+
+Good additions are small, dependency-light helpers that at least two projects share and that no upstream library covers cleanly.
+
+## Questions?
+
+- Open an issue at https://github.com/a-novel-kit/nodelib/issues
+- Check existing issues for similar problems
+- Include relevant logs and environment details

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,44 +1,42 @@
 # Contributing to nodelib
 
-For platform-wide setup (Go, Node, Podman, the `a-novel` CLI) and the day-to-day commands, see the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md). This file documents what is specific to `nodelib`.
+Platform setup and day-to-day commands are in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md). This file covers what's specific to `nodelib`.
 
 ## Repo layout
 
-`nodelib` is a [pnpm](https://pnpm.io) workspace. Every published package lives under `packages/*`, each exposing its source directly (no `src/` indirection) with a colocated `package.json`, `tsconfig.json`, and `vite.config.ts`:
+`nodelib` is a [pnpm](https://pnpm.io) workspace. Every published package lives under `packages/*` with its own `package.json` and build config:
 
 - `packages/browser` → `@a-novel-kit/nodelib-browser`
 - `packages/configs` → `@a-novel-kit/nodelib-config`
 - `packages/test` → `@a-novel-kit/nodelib-test`
 
-Shared dependency versions are pinned through the workspace catalog in `pnpm-workspace.yaml` (the `catalog:` entries in each `package.json`).
+Shared dependency versions are pinned via the `pnpm-workspace.yaml` catalog.
 
 ## Working in the repo
 
 All commands run from the repo root:
 
 - `pnpm install` — install the workspace.
-- `pnpm build` — compile every package (Vite bundle + `tsc` type declarations) into its `dist/`.
-- `pnpm test` — run the [Vitest](https://vitest.dev) suite; tests are colocated as `*.test.ts` files next to their sources.
-- `pnpm lint` — run Prettier (style check), `tsc --noEmit` (type check), and ESLint.
+- `pnpm build` — bundle every package into its `dist/` (Vite + `tsc` declarations).
+- `pnpm test` — run the [Vitest](https://vitest.dev) suite (`*.test.ts` beside its source).
+- `pnpm lint` — Prettier check, `tsc --noEmit`, and ESLint.
 - `pnpm format` — apply Prettier across the workspace.
 
-CI runs `pnpm lint:ci` and `pnpm test:ci`, which build the config and browser packages first so the rest of the workspace can resolve them. Prettier is gated in CI, so run `pnpm format` before committing.
+CI builds the config and browser packages first so the rest can resolve them, and gates on Prettier — run `pnpm format` before committing.
 
 ## Publishing
 
-Packages are published to GitHub Packages under the `@a-novel-kit/` scope. The three packages share a single version, bumped together via `pnpm version` and released by pushing the resulting tag (`git push --follow-tags`); the release workflow builds and publishes from the tag.
+Packages publish to GitHub Packages under `@a-novel-kit/`. All three share one version: bump them together (`pnpm version`) and push the tag (`git push --follow-tags`); the release workflow publishes from it.
 
 ## The bar for additions
 
-`nodelib` stays small on purpose — it holds only the glue two or more projects would otherwise copy between repos. Weigh any addition against two questions:
+`nodelib` stays small on purpose. Weigh any addition against two questions:
 
 - Does a well-maintained library already do it? Use that library; don't wrap it here.
 - Does only one project need it? Keep it there until a second one does.
 
-The sweet spot is a small, dependency-light helper that several projects share and nothing upstream covers cleanly.
+The sweet spot: a small, dependency-light helper several projects share that nothing upstream covers cleanly.
 
 ## Questions?
 
-- Open an issue at https://github.com/a-novel-kit/nodelib/issues
-- Check existing issues for similar problems
-- Include relevant logs and environment details
+[Open an issue](https://github.com/a-novel-kit/nodelib/issues) — include logs and environment details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,12 +30,12 @@ Packages are published to GitHub Packages under the `@a-novel-kit/` scope. The t
 
 ## The bar for additions
 
-`nodelib` is intentionally minimal — it holds only the cross-cutting glue that the frontends and tooling would otherwise copy between repos. Before adding to it, weigh the addition against this bar:
+`nodelib` stays small on purpose — it holds only the glue two or more projects would otherwise copy between repos. Weigh any addition against two questions:
 
-- **A well-maintained library already does it?** Use that library directly; do not wrap it here.
-- **Only one project needs it?** Keep it in that project until a second one does.
+- Does a well-maintained library already do it? Use that library; don't wrap it here.
+- Does only one project need it? Keep it there until a second one does.
 
-Good additions are small, dependency-light helpers that at least two projects share and that no upstream library covers cleanly.
+The sweet spot is a small, dependency-light helper that several projects share and nothing upstream covers cleanly.
 
 ## Questions?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node lib
 
-The shared Node.js/TypeScript packages the A-Novel frontends and tooling reuse — HTTP/utility helpers, the common ESLint + Prettier config, and the test toolkit.
+The shared Node.js/TypeScript packages the A-Novel frontends and tooling reuse.
 
 [![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/agorastoryverse)](https://twitter.com/agorastoryverse)
 [![Discord](https://img.shields.io/discord/1315240114691248138?logo=discord)](https://discord.gg/rp4Qr8cA)
@@ -17,7 +17,7 @@ The shared Node.js/TypeScript packages the A-Novel frontends and tooling reuse �
 
 ## What this is
 
-`nodelib` collects the small amount of cross-cutting glue that the A-Novel frontends and JS/TS tooling would otherwise copy from one repo to the next — fetch/HTTP error handling, browser utilities, the shared ESLint and Prettier configuration, and a test toolkit. It is the JS/TS analogue of [`golib`](https://github.com/a-novel-kit/golib): a pnpm workspace that publishes a handful of focused, independently installable packages under the `@a-novel-kit/` scope on GitHub Packages. It is deliberately kept minimal — anything a well-maintained dependency already covers belongs in that dependency, not here.
+`nodelib` collects the cross-cutting glue that the A-Novel frontends and JS/TS tooling would otherwise copy from one repo to the next — the JS/TS analogue of [`golib`](https://github.com/a-novel-kit/golib). It is a pnpm workspace that publishes a handful of focused, independently installable packages under the `@a-novel-kit/` scope, kept deliberately small.
 
 ## Installation
 
@@ -38,12 +38,12 @@ pnpm add -D @a-novel-kit/nodelib-test
 
 ## Packages
 
-| Package                        | What it provides                                                                                                                                                                                                                                                       | Install                                   |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `@a-novel-kit/nodelib-browser` | Browser runtime helpers. `./http`: the `HttpError` class and `newHttpError` / `isHttpError` / `isHttpStatusError` guards, `handleHttpResponse`, Zod-backed `decodeHttpResponse`, and `HTTP_HEADERS`. `./utils`: a `Debounce` class and a configurable `retry` wrapper. | `pnpm add @a-novel-kit/nodelib-browser`   |
-| `@a-novel-kit/nodelib-config`  | The shared dev-tooling config. `Eslint(opts)` builds the flat ESLint config (TypeScript plus optional Svelte / Storybook layers) and `Prettier(opts)` builds the Prettier config (with optional Svelte / SQL plugins and the standard import-order rules).             | `pnpm add -D @a-novel-kit/nodelib-config` |
-| `@a-novel-kit/nodelib-test`    | The test toolkit. `./msw`: a fluent MSW request-matcher builder (body / headers / path & search params). `./http`: `expectStatus`. `./form`: the `writeField` Testing-Library helper. `./mocks/tolgee` and `./mocks/query_client`: ready-made mocks.                   | `pnpm add -D @a-novel-kit/nodelib-test`   |
+| Package                        | What it provides                                                                                                                           | Install                                   |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
+| `@a-novel-kit/nodelib-browser` | Browser runtime helpers: typed HTTP error handling and Zod-backed response decoding, plus small utilities (debounce, retry).               | `pnpm add @a-novel-kit/nodelib-browser`   |
+| `@a-novel-kit/nodelib-config`  | Shared dev-tooling config: factories for the flat ESLint and Prettier configs (TypeScript, with optional Svelte / Storybook / SQL layers). | `pnpm add -D @a-novel-kit/nodelib-config` |
+| `@a-novel-kit/nodelib-test`    | Test toolkit: a fluent MSW request-matcher builder, HTTP/form assertions, and ready-made mocks (Tolgee, query client).                     | `pnpm add -D @a-novel-kit/nodelib-test`   |
 
 ## Contributing
 
-Platform setup and the day-to-day commands live in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md); `nodelib`-specific notes are in [CONTRIBUTING.md](./CONTRIBUTING.md). The bar for additions is deliberately high — convenience wrappers around well-maintained dependencies, and one-off helpers only one project needs, do not belong here.
+Platform setup and the day-to-day commands live in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md); `nodelib`-specific notes are in [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node lib
 
-Shared Node.js libraries.
+The shared Node.js/TypeScript packages the A-Novel frontends and tooling reuse — HTTP/utility helpers, the common ESLint + Prettier config, and the test toolkit.
 
 [![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/agorastoryverse)](https://twitter.com/agorastoryverse)
 [![Discord](https://img.shields.io/discord/1315240114691248138?logo=discord)](https://discord.gg/rp4Qr8cA)
@@ -15,26 +15,35 @@ Shared Node.js libraries.
 
 ![Coverage graph](https://codecov.io/gh/a-novel-kit/nodelib/graphs/sunburst.svg)
 
+## What this is
+
+`nodelib` collects the small amount of cross-cutting glue that the A-Novel frontends and JS/TS tooling would otherwise copy from one repo to the next — fetch/HTTP error handling, browser utilities, the shared ESLint and Prettier configuration, and a test toolkit. It is the JS/TS analogue of [`golib`](https://github.com/a-novel-kit/golib): a pnpm workspace that publishes a handful of focused, independently installable packages under the `@a-novel-kit/` scope on GitHub Packages. It is deliberately kept minimal — anything a well-maintained dependency already covers belongs in that dependency, not here.
+
 ## Installation
 
-> ⚠️ **Warning**: Even though the package is public, GitHub registry requires you to have a Personal Access Token
-> with `repo` and `read:packages` scopes to pull it in your project. See
-> [this issue](https://github.com/orgs/community/discussions/23386#discussioncomment-3240193) for more information.
-
-Create a `.npmrc` file in the root of your project if it doesn't exist, and make sure it contains the following:
+The packages are published to GitHub Packages, which requires a Personal Access Token with `read:packages` scope even though the packages are public ([details](https://github.com/orgs/community/discussions/23386#discussioncomment-3240193)). Add an `.npmrc` at your project root:
 
 ```ini
 @a-novel-kit:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${YOUR_PERSONAL_ACCESS_TOKEN}
 ```
 
-Then, install the package using pnpm (you can install any package independently):
+Then install the package(s) you need (each is published independently):
 
 ```bash
-# pnpm config set auto-install-peers true
-#  Or
-# pnpm config set auto-install-peers true --location project
-pnpm add -D @a-novel-kit/nodelib-test
-pnpm add -D @a-novel-kit/nodelib-config
 pnpm add @a-novel-kit/nodelib-browser
+pnpm add -D @a-novel-kit/nodelib-config
+pnpm add -D @a-novel-kit/nodelib-test
 ```
+
+## Packages
+
+| Package                        | What it provides                                                                                                                                                                                                                                                       | Install                                   |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `@a-novel-kit/nodelib-browser` | Browser runtime helpers. `./http`: the `HttpError` class and `newHttpError` / `isHttpError` / `isHttpStatusError` guards, `handleHttpResponse`, Zod-backed `decodeHttpResponse`, and `HTTP_HEADERS`. `./utils`: a `Debounce` class and a configurable `retry` wrapper. | `pnpm add @a-novel-kit/nodelib-browser`   |
+| `@a-novel-kit/nodelib-config`  | The shared dev-tooling config. `Eslint(opts)` builds the flat ESLint config (TypeScript plus optional Svelte / Storybook layers) and `Prettier(opts)` builds the Prettier config (with optional Svelte / SQL plugins and the standard import-order rules).             | `pnpm add -D @a-novel-kit/nodelib-config` |
+| `@a-novel-kit/nodelib-test`    | The test toolkit. `./msw`: a fluent MSW request-matcher builder (body / headers / path & search params). `./http`: `expectStatus`. `./form`: the `writeField` Testing-Library helper. `./mocks/tolgee` and `./mocks/query_client`: ready-made mocks.                   | `pnpm add -D @a-novel-kit/nodelib-test`   |
+
+## Contributing
+
+Platform setup and the day-to-day commands live in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md); `nodelib`-specific notes are in [CONTRIBUTING.md](./CONTRIBUTING.md). The bar for additions is deliberately high — convenience wrappers around well-maintained dependencies, and one-off helpers only one project needs, do not belong here.

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ pnpm add -D @a-novel-kit/nodelib-test
 
 ## Packages
 
-| Package                        | What it provides                                                                                                                           | Install                                   |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
-| `@a-novel-kit/nodelib-browser` | Browser runtime helpers: typed HTTP error handling and Zod-backed response decoding, plus small utilities (debounce, retry).               | `pnpm add @a-novel-kit/nodelib-browser`   |
-| `@a-novel-kit/nodelib-config`  | Shared dev-tooling config: factories for the flat ESLint and Prettier configs (TypeScript, with optional Svelte / Storybook / SQL layers). | `pnpm add -D @a-novel-kit/nodelib-config` |
-| `@a-novel-kit/nodelib-test`    | Test toolkit: a fluent MSW request-matcher builder, HTTP/form assertions, and ready-made mocks (Tolgee, query client).                     | `pnpm add -D @a-novel-kit/nodelib-test`   |
+| Package                        | What it's for                                                                                                                                                                             | Install                                   |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `@a-novel-kit/nodelib-browser` | Bundles the runtime helpers the browser apps share, so each frontend handles HTTP responses and errors the same way instead of reinventing them. A few async utilities live here too.     | `pnpm add @a-novel-kit/nodelib-browser`   |
+| `@a-novel-kit/nodelib-config`  | Provides the shared ESLint and Prettier setup as factories, so each repo enables only the layers it needs — TypeScript, Svelte, Storybook, SQL — instead of copying configuration around. | `pnpm add -D @a-novel-kit/nodelib-config` |
+| `@a-novel-kit/nodelib-test`    | Gathers the testing tools the frontends share — request mocking, response assertions, and prebuilt service mocks — so tests read consistently and stay quick to write.                    | `pnpm add -D @a-novel-kit/nodelib-test`   |
 
 ## Contributing
 


### PR DESCRIPTION
Standardizes `nodelib`'s docs to the kit-library exemplar (matching the just-approved `golib` README/CONTRIBUTING).

## README.md
- Adds the missing one-line description under the title; keeps the existing badges (file count, code size, `main.yaml` workflow status, codecov badge + sunburst).
- New `## What this is` framing nodelib as the JS/TS analogue of `golib`.
- Trims the verbose GitHub Packages install blockquote to one concise sentence + the `.npmrc` snippet + per-package `pnpm add` lines.
- New `## Packages` table — one row per published package, verified against each package's `package.json` exports and sources:
  - `@a-novel-kit/nodelib-browser` — `./http` (`HttpError`, guards, `handleHttpResponse`, Zod `decodeHttpResponse`, `HTTP_HEADERS`) + `./utils` (`Debounce`, `retry`).
  - `@a-novel-kit/nodelib-config` — `Eslint()` / `Prettier()` shared-config factories (Svelte / Storybook / SQL opt-ins).
  - `@a-novel-kit/nodelib-test` — `./msw` matcher builder, `./http` `expectStatus`, `./form` `writeField`, `./mocks/tolgee`, `./mocks/query_client`.
- `## Contributing` links the org onboarding guide and `./CONTRIBUTING.md`.

## CONTRIBUTING.md (new)
Mirrors `golib`'s shape: links the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md), then nodelib-specific notes (pnpm-workspace layout, build/test/lint/format commands, publish flow) and a `## Questions?` block.

## CODE_OF_CONDUCT.md
Replaces the `[INSERT CONTACT METHOD]` placeholder with the contact email.

Prettier `--check` passes on all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)