### PR TITLE
docs: link concepts doc; define package/workspace/catalog + graduation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,16 @@
 # Contributing to nodelib
 
-Platform setup and day-to-day commands are in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md). This file covers what's specific to `nodelib`.
+The library taxonomy — what a library is, the aggregated-vs-graduated split, and the public-package obligations a graduated package takes on — lives in the [libraries, tooling & platform concepts](https://github.com/a-novel-kit/.github/blob/master/CONTRIBUTING.md); this file covers what's specific to `nodelib`. Platform setup and day-to-day commands are in the [developer onboarding guide](https://github.com/a-novel-kit/.github/blob/master/README.md).
 
 ## Repo layout
 
-`nodelib` is a [pnpm](https://pnpm.io) workspace. Every published package lives under `packages/*` with its own `package.json` and build config:
+`nodelib` is a [pnpm](https://pnpm.io) **workspace** — one repository hosting several independently published **packages** that share tooling and a single version. Each package lives under `packages/*` with its own `package.json` and build config:
 
 - `packages/browser` → `@a-novel-kit/nodelib-browser`
 - `packages/configs` → `@a-novel-kit/nodelib-config`
 - `packages/test` → `@a-novel-kit/nodelib-test`
 
-Shared dependency versions are pinned via the `pnpm-workspace.yaml` catalog.
+Shared dependency versions are pinned once in the `pnpm-workspace.yaml` **catalog**, so every package resolves the same version of a shared dependency.
 
 ## Working in the repo
 
@@ -30,10 +30,11 @@ Packages publish to GitHub Packages under `@a-novel-kit/`. All three share one v
 
 ## The bar for additions
 
-`nodelib` stays small on purpose. Weigh any addition against two questions:
+`nodelib` stays small on purpose. Weigh any addition against three questions:
 
 - Does a well-maintained library already do it? Use that library; don't wrap it here.
 - Does only one project need it? Keep it there until a second one does.
+- Has a package grown a broad API of its own? Then it [graduates](https://github.com/a-novel-kit/.github/blob/master/CONTRIBUTING.md#libraries) out of the workspace into its own repo — taking on the public-package obligations that come with standing alone: its own README/CONTRIBUTING/SECURITY/CODE_OF_CONDUCT, Codecov, and a semver policy it holds to.
 
 The sweet spot: a small, dependency-light helper several projects share that nothing upstream covers cleanly.
 


### PR DESCRIPTION
## Summary

- Link CONTRIBUTING to the [libraries, tooling & platform concepts](https://github.com/a-novel-kit/.github/blob/master/CONTRIBUTING.md) (the #30 deliverable).
- Define **workspace**, **package**, and **catalog** explicitly in the repo-layout section.
- Add the missing **graduation path** (a package that grows a broad API of its own graduates out of the workspace into its own repo, taking on the public-package obligations) — aligning with golib + the concepts doc.

Doc-only; no code change. Part of the **Taxonomy & glossary** milestone (a-novel-kit/.github#29).

Closes #566