### PR TITLE
docs: refocus comments on rationale and refine project docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ CI builds the config and browser packages first so the rest can resolve them, an
 
 ## Publishing
 
-Packages publish to GitHub Packages under `@a-novel-kit/`. All three share one version: bump them together (`pnpm version`) and push the tag (`git push --follow-tags`); the release workflow publishes from it.
+Packages publish to GitHub Packages under `@a-novel-kit/`, and all three share one version so they release together. Cut a release from the GitHub UI (**Actions ▸ release**), choosing the bump type; the workflow bumps the shared version, tags the commit, and publishes from that tag. A protected `release` environment gates who can publish.
 
 ## The bar for additions
 

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ pnpm add -D @a-novel-kit/nodelib-test
 
 ## Packages
 
-| Package                        | What it's for                                                                                                                                                                             | Install                                   |
-| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
-| `@a-novel-kit/nodelib-browser` | Bundles the runtime helpers the browser apps share, so each frontend handles HTTP responses and errors the same way instead of reinventing them. A few async utilities live here too.     | `pnpm add @a-novel-kit/nodelib-browser`   |
-| `@a-novel-kit/nodelib-config`  | Provides the shared ESLint and Prettier setup as factories, so each repo enables only the layers it needs — TypeScript, Svelte, Storybook, SQL — instead of copying configuration around. | `pnpm add -D @a-novel-kit/nodelib-config` |
-| `@a-novel-kit/nodelib-test`    | Gathers the testing tools the frontends share — request mocking, response assertions, and prebuilt service mocks — so tests read consistently and stay quick to write.                    | `pnpm add -D @a-novel-kit/nodelib-test`   |
+| Package                        | What it's for                                                                                                                                                                         | Install                                   |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `@a-novel-kit/nodelib-browser` | Bundles the runtime helpers the browser apps share, so each frontend handles HTTP responses and errors the same way instead of reinventing them. A few async utilities live here too. | `pnpm add @a-novel-kit/nodelib-browser`   |
+| `@a-novel-kit/nodelib-config`  | Provides the shared ESLint and Prettier setup as factories, so each repo enables only the layers it needs (Svelte or Storybook, say) instead of copying configuration around.         | `pnpm add -D @a-novel-kit/nodelib-config` |
+| `@a-novel-kit/nodelib-test`    | Gathers the testing tools the frontends share, like request mocking and prebuilt service mocks, so tests read consistently and stay quick to write.                                   | `pnpm add -D @a-novel-kit/nodelib-test`   |
 
 ## Contributing
 

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -1,19 +1,25 @@
 # Node (browser)
 
+Browser-side helpers for the A-Novel frontends: `fetch` response handling — turning failed
+responses into typed errors and validating JSON bodies against a Zod schema — under
+`@a-novel-kit/nodelib-browser/http`, and standalone utilities (debounce, retry) under
+`@a-novel-kit/nodelib-browser/utils`.
+
 ## Installation
 
-> ⚠️ **Warning**: Even though the package is public, GitHub registry requires you to have a Personal Access Token
-> with `repo` and `read:packages` scopes to pull it in your project. See
+> ⚠️ **Warning**: Even though the package is public, GitHub Packages requires a Personal Access Token
+> with the `read:packages` scope to pull it into your project. See
 > [this issue](https://github.com/orgs/community/discussions/23386#discussioncomment-3240193) for more information.
 
-Create a `.npmrc` file in the root of your project if it doesn't exist, and make sure it contains the following:
+Create a `.npmrc` file at the root of your project if it doesn't exist, and make sure it contains the following:
 
 ```ini
-@a-novel:registry=https://npm.pkg.github.com
+@a-novel-kit:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=${YOUR_PERSONAL_ACCESS_TOKEN}
 ```
 
-Then, install the package using pnpm:
+Then install the package with pnpm. It declares `zod` as a peer dependency, so enable
+`auto-install-peers` if your setup does not resolve peers on its own:
 
 ```bash
 # pnpm config set auto-install-peers true

--- a/packages/browser/http/error.ts
+++ b/packages/browser/http/error.ts
@@ -1,5 +1,6 @@
 /**
- * Wrap a failed HTTP response in an Error object, while keeping its content.
+ * HttpError represents a non-2xx HTTP response, keeping the status code and body text
+ * so callers can inspect them after the request has failed.
  */
 export class HttpError extends Error {
   private readonly _status: number;
@@ -16,17 +17,24 @@ export class HttpError extends Error {
   }
 }
 
+/**
+ * newHttpError builds an HttpError from a failed response, reading its body as text. A body
+ * that cannot be decoded is replaced with the decode error message rather than rejecting.
+ */
 export async function newHttpError(response: Response): Promise<HttpError> {
   const text = await response.text().catch((err) => `failed to decode response: ${err.message}`);
   return new HttpError(response.status, text);
 }
 
+/**
+ * isHttpError narrows an unknown error to an HttpError.
+ */
 export function isHttpError(error: unknown): error is HttpError {
   return error instanceof Error && error.name === "HttpError";
 }
 
 /**
- * Check if the given error is an HttpError with one of the given status codes.
+ * isHttpStatusError reports whether the error is an HttpError carrying one of the given status codes.
  */
 export function isHttpStatusError(error: unknown, ...status: number[]): boolean {
   return isHttpError(error) && status.includes(error.status);

--- a/packages/browser/http/headers.ts
+++ b/packages/browser/http/headers.ts
@@ -1,5 +1,6 @@
 /**
- * Default HTTP headers.
+ * HTTP_HEADERS collects reusable request header presets. Each entry is a getter, so callers
+ * receive a fresh object and cannot mutate the shared preset.
  */
 export const HTTP_HEADERS = {
   get JSON() {

--- a/packages/browser/http/index.ts
+++ b/packages/browser/http/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Browser-side helpers for fetch requests: turning failed responses into typed errors, decoding
+ * and validating JSON bodies against a Zod schema, and common request headers.
+ */
+
 export * from "./error";
 export * from "./headers";
 export * from "./response";

--- a/packages/browser/http/response.ts
+++ b/packages/browser/http/response.ts
@@ -3,7 +3,8 @@ import { newHttpError } from "./error";
 import type { ZodType } from "zod";
 
 /**
- * Check the response status, and throw an HttpError if not ok (2xx).
+ * handleHttpResponse passes an ok (2xx) response through unchanged and throws an HttpError for
+ * any other status.
  */
 export async function handleHttpResponse(response: Response): Promise<Response> {
   if (!response.ok) {
@@ -13,7 +14,8 @@ export async function handleHttpResponse(response: Response): Promise<Response> 
 }
 
 /**
- * Decode the JSON body of an HTTP response, and validate it using the given Zod validator.
+ * decodeHttpResponse builds a response handler that parses the JSON body and validates it against
+ * the given Zod schema, resolving to the typed value or rejecting on a validation failure.
  */
 export function decodeHttpResponse<T>(validator: ZodType<T>) {
   return async function (response: Response): Promise<T> {

--- a/packages/browser/utils/debounce.ts
+++ b/packages/browser/utils/debounce.ts
@@ -1,3 +1,9 @@
+/**
+ * Debounce collapses a burst of rapid calls into at most one execution per quiet period. The first
+ * call in a burst runs immediately; while further calls keep arriving, each supersedes the last and
+ * only the final one runs, fired once the calls stop. This keeps a leading response snappy while
+ * shielding the target function from repeated triggers.
+ */
 export class Debounce {
   private _immediate: boolean;
   private readonly _delay: number;
@@ -6,11 +12,9 @@ export class Debounce {
   private _cooldownTimer: ReturnType<typeof setTimeout> | undefined;
 
   /**
-   * Creates a new Debounce instance.
-   * @param delay - Duration in milliseconds to wait before executing the function after the last call.
-   * @param cooldownReset - Duration in milliseconds before allowing another immediate execution.
-   *                        Defaults to the same value as delay. Unlike delay, cooldownReset controls
-   *                        how soon a subsequent call can bypass the delay and execute immediately.
+   * @param delay - Milliseconds of quiet required after the last call before the trailing call runs.
+   * @param cooldownReset - Milliseconds of quiet after which an incoming call is again allowed to run
+   *   immediately instead of being delayed. Defaults to `delay`.
    */
   constructor(delay: number, cooldownReset: number = delay) {
     this._delay = delay;
@@ -19,16 +23,15 @@ export class Debounce {
   }
 
   private _shouldExecuteImmediately(): boolean {
-    // If a cooldown is active, delay it again.
-    // Otherwise, activate it.
+    // Every call restarts the cooldown; the immediate slot only reopens once calls stop for a full
+    // cooldown window.
     clearTimeout(this._cooldownTimer);
     this._cooldownTimer = setTimeout(() => {
       this._cooldownTimer = undefined;
-      // Allow immediate execution again for a single call.
       this._immediate = true;
     }, this._cooldownReset);
 
-    // We allow the current call and only this one to ignore the delay, while the cooldown is active.
+    // Only the first call of a burst may skip the delay.
     if (this._immediate) {
       this._immediate = false;
       return true;
@@ -38,9 +41,8 @@ export class Debounce {
   }
 
   /**
-   * Cancels any pending delayed execution and resets the immediate execution state.
-   * This will clear any active timers, preventing the debounced function from being called
-   * if it was scheduled but not yet executed.
+   * Cancels a pending trailing execution and resets the debouncer, so the next call runs
+   * immediately as if the instance were fresh.
    */
   cancel() {
     clearTimeout(this._timer);
@@ -49,10 +51,12 @@ export class Debounce {
     this._immediate = true;
   }
 
+  /**
+   * Feeds a call into the debouncer. The function runs immediately when the debouncer is idle,
+   * otherwise it is scheduled and supersedes any call still waiting to run.
+   */
   call(fn: () => void) {
     clearTimeout(this._timer);
-    // To prevent initial delay, the first call after some time is immediately executed and activates the cooldown
-    // timer.
     if (this._shouldExecuteImmediately()) {
       fn();
       return;

--- a/packages/browser/utils/retry.ts
+++ b/packages/browser/utils/retry.ts
@@ -1,9 +1,14 @@
+/**
+ * A RetryFailureFn produces the final result once retrying gives up. It receives the last error
+ * and the arguments the call was made with, and either returns a fallback value or throws.
+ */
 export type RetryFailureFn<T, Params extends unknown[]> = (error: unknown, ...params: Params) => T;
 
 function defaultRetryFailureFn<T, Params extends unknown[]>(err: unknown, ..._: Params): T {
   throw err;
 }
 
+/** RetryParams tunes {@link retry}: the attempt budget, the pause between attempts, and how a terminal failure is handled. */
 export interface RetryParams<T, Params extends unknown[]> {
   /**
    * Total number of attempts (including the initial attempt) before failing.
@@ -15,26 +20,30 @@ export interface RetryParams<T, Params extends unknown[]> {
    * @default 1000
    */
   delay?: number;
-  /** Function to call on failure after all retries are exhausted.
-   * By default, it throws the last error encountered.
+  /**
+   * Called once every attempt is exhausted (or once `condition` rejects an error). Rethrows the
+   * last error by default.
    */
   onFailure?: RetryFailureFn<T, Params>;
   /**
-   * If condition returns false, immediately stop retrying and call onFailure.
+   * Decides whether a thrown error is retryable. Returning false stops retrying at once and defers
+   * to `onFailure`. Every error is retried by default.
    */
   condition?: (err: unknown) => boolean;
 }
 
 /**
- * Retry a function call a number of times with a delay.
+ * Wraps a callback so failed invocations are transparently retried. The returned function retries
+ * on each thrown error until the callback succeeds, the attempt budget runs out, or an error is
+ * marked non-retryable, at which point it defers to the failure handler.
  */
 export function retry<T, Params extends unknown[]>(
   callback: (...params: Params) => T | Promise<T>,
   {
     retries = 3,
     delay = 1000,
-    onFailure = defaultRetryFailureFn<T, Params>, // Rethrow error by default.
-    condition = () => true, // Always retry by default.
+    onFailure = defaultRetryFailureFn<T, Params>,
+    condition = () => true,
   }: RetryParams<T, Params> = {}
 ): (...params: Params) => Promise<T> {
   return async function doRetry(...params: Params): Promise<T> {

--- a/packages/configs/eslint-base.ts
+++ b/packages/configs/eslint-base.ts
@@ -9,15 +9,25 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import globals from "globals";
 import ts from "typescript-eslint";
 
+/** Options for {@link Eslint}, toggling the framework plugins and ignore sources a package needs. */
 export interface EslintOptions {
+  /** Treats the package as a reusable library, relaxing rules that assume a deployed app with a fixed route table. */
   isLib?: boolean;
+  /** Svelte config; when provided, enables Svelte parsing and its recommended and Prettier rule sets. */
   svelte?: SvelteConfig;
   storybook?: boolean;
   ignores?: string[];
+  /** Path to a .gitignore file whose patterns are converted into ESLint ignores. */
   gitIgnorePath?: string;
+  /** Extra flat-config block deep-merged over the defaults, so a package can add or override rules. */
   customRules?: ConfigWithExtends;
 }
 
+/**
+ * Builds the shared flat ESLint config for a-novel Node and Svelte packages. The returned array is
+ * ready to spread into a package's eslint.config; pass {@link EslintOptions} to enable Svelte,
+ * Storybook, or library-specific rules.
+ */
 export function Eslint(opts: EslintOptions = {}): Parameters<typeof defineConfig> {
   let customRules: ConfigWithExtends = {
     languageOptions: {
@@ -39,7 +49,7 @@ export function Eslint(opts: EslintOptions = {}): Parameters<typeof defineConfig
     },
   };
 
-  // Only ignore links without resolve in lib mode, as they can be generic, reusable elements.
+  // In library mode links can be generic and reusable, with no concrete route table to resolve against.
   if (opts.svelte && opts.isLib) {
     customRules.rules!["svelte/no-navigation-without-resolve"] = ["error", { ignoreLinks: true }];
   }
@@ -58,7 +68,8 @@ export function Eslint(opts: EslintOptions = {}): Parameters<typeof defineConfig
     };
   }
 
-  // Make sure to insert rules in the correct order.
+  // Flat config lets later blocks override earlier ones, so group by precedence and keep the Prettier
+  // style block last so it can switch off formatting rules the other blocks turn on.
   const sortedRules: Record<string, ConfigWithExtends[]> = {
     ignoreRules: [globalIgnores(["**/dist/**", "**/.*/**", ...(opts.ignores ?? [])])],
     langRules: [js.configs.recommended, ...ts.configs.recommended],
@@ -82,7 +93,7 @@ export function Eslint(opts: EslintOptions = {}): Parameters<typeof defineConfig
       },
     });
     customRules.rules!["@typescript-eslint/no-empty-object-type"] = "off";
-    // We only use it for internal content. This is never used to render user inputs.
+    // Disabled because {@html} only renders internal content here, never user input.
     customRules.rules!["svelte/no-at-html-tags"] = "off";
   }
 

--- a/packages/configs/index.ts
+++ b/packages/configs/index.ts
@@ -1,2 +1,4 @@
+/** Shared ESLint and Prettier config factories for a-novel Node and Svelte packages. */
+
 export * from "./prettier-base";
 export * from "./eslint-base";

--- a/packages/configs/prettier-base.ts
+++ b/packages/configs/prettier-base.ts
@@ -2,11 +2,16 @@ import type { PrettierConfig as SortImportsConfig } from "@trivago/prettier-plug
 import type { Config } from "prettier";
 import type { SqlOptions } from "prettier-plugin-sql";
 
+/** Options for {@link Prettier}, enabling the Svelte and SQL plugin chains a package needs. */
 export interface PrettierOptions {
   svelte?: boolean;
   sql?: boolean;
 }
 
+/**
+ * Builds the shared Prettier config for a-novel packages, wiring in import sorting and package.json
+ * formatting. Pass {@link PrettierOptions} to add Svelte or SQL formatting.
+ */
 export function Prettier(opts: PrettierOptions = {}): Config & SortImportsConfig & Partial<SqlOptions> {
   const baseConfig: Config & SortImportsConfig & Partial<SqlOptions> = {
     useTabs: false,

--- a/packages/test/form/index.ts
+++ b/packages/test/form/index.ts
@@ -3,7 +3,7 @@ import { expect } from "vitest";
 import { act, fireEvent, waitFor } from "@testing-library/react";
 
 /**
- * writeField types value into a text field and resolves once the field settles on expectValue.
+ * writeField writes value into a text field and resolves once the field settles on expectValue.
  * Pass expectValue when the field transforms its input (a mask, for example); it defaults to the
  * written value.
  */

--- a/packages/test/form/index.ts
+++ b/packages/test/form/index.ts
@@ -3,7 +3,9 @@ import { expect } from "vitest";
 import { act, fireEvent, waitFor } from "@testing-library/react";
 
 /**
- * Write a value to a text field and wait for the value to be set.
+ * writeField types value into a text field and resolves once the field settles on expectValue.
+ * Pass expectValue when the field transforms its input (a mask, for example); it defaults to the
+ * written value.
  */
 export const writeField = async (field: HTMLElement, value: string, expectValue: string = value) => {
   act(() => {

--- a/packages/test/http/err.ts
+++ b/packages/test/http/err.ts
@@ -8,6 +8,10 @@ function prettyRes(res: any): string {
   }
 }
 
+/**
+ * expectStatus awaits callback and asserts that it rejects with an HTTP error carrying the given
+ * status code, throwing a descriptive failure otherwise.
+ */
 export async function expectStatus(callback: Promise<any>, status: number) {
   const res = await callback.catch((err) => err);
 

--- a/packages/test/http/err.ts
+++ b/packages/test/http/err.ts
@@ -9,8 +9,8 @@ function prettyRes(res: any): string {
 }
 
 /**
- * expectStatus awaits callback and asserts that it rejects with an HTTP error carrying the given
- * status code, throwing a descriptive failure otherwise.
+ * expectStatus awaits the given promise and asserts that it rejects with an HTTP error carrying the
+ * given status code, throwing a descriptive failure otherwise.
  */
 export async function expectStatus(callback: Promise<any>, status: number) {
   const res = await callback.catch((err) => err);

--- a/packages/test/mocks/query_client/index.ts
+++ b/packages/test/mocks/query_client/index.ts
@@ -1,14 +1,17 @@
 import type { QueryClientConfig } from "@tanstack/react-query";
 
+/**
+ * MockQueryClient is a react-query configuration for tests: it disables retries and freezes the
+ * stale time so background refetches never fire, leaving tests in full control of which queries run.
+ */
 export const MockQueryClient: QueryClientConfig = {
   defaultOptions: {
     queries: {
       retry: false,
-      // Setting the stale time avoids refreshes, and allow use to have more control
-      // over which query we expect to be made.
       staleTime: Infinity,
     },
   },
 };
 
+/** MockHeaders is the default JSON request header set for mocked HTTP responses. */
 export const MockHeaders = { "Content-Type": "application/json" };

--- a/packages/test/mocks/tolgee/index.ts
+++ b/packages/test/mocks/tolgee/index.ts
@@ -2,6 +2,12 @@ import { vi } from "vitest";
 
 const mergeKeyAndNs = (key: string, ns?: string | null) => (ns ? `${ns}:${key}` : key);
 
+/**
+ * tolgeeMock builds a vitest module-mock factory for the Tolgee React bindings. It replaces the
+ * translation hooks and components with deterministic stand-ins that echo the namespaced key
+ * instead of resolving real translations, so tests can assert on stable strings. Pass the module's
+ * importOriginal so untouched exports pass through.
+ */
 export const tolgeeMock = async (importOriginal: () => any) => {
   const original = await importOriginal();
 

--- a/packages/test/mswHelpers/body.ts
+++ b/packages/test/mswHelpers/body.ts
@@ -1,6 +1,7 @@
 import { isEqual } from "lodash-es";
 import { HttpResponse } from "msw";
 
+/** Matches the request's JSON body against `expect` by deep equality, or defers to `expect` when it is a predicate. */
 export const matchBodyJSON = async <Body>(
   request: Request,
   expect: Body | ((req: Body) => boolean | HttpResponse<any>)
@@ -14,6 +15,7 @@ export const matchBodyJSON = async <Body>(
   return isEqual(actualBody, expect as Body);
 };
 
+/** Matches the request's text body against `expect` by exact equality, or defers to `expect` when it is a predicate. */
 export const matchBodyText = async (
   request: Request,
   expect: string | ((req: string) => boolean | HttpResponse<any>)
@@ -27,6 +29,12 @@ export const matchBodyText = async (
   return actualBody === expect;
 };
 
+/**
+ * Matches the request's form-data body against `expect`, or defers to `expect` when it is a predicate.
+ *
+ * Every field carried by the request must appear in `expect` with an equal value; fields present only in `expect`
+ * are ignored.
+ */
 export const matchBodyFormData = async (
   request: Request,
   expect: FormData | ((req: FormData) => boolean | HttpResponse<any>)
@@ -46,6 +54,7 @@ export const matchBodyFormData = async (
   return true;
 };
 
+/** Matches the request's raw byte body against `expect` by deep equality, or defers to `expect` when it is a predicate. */
 export const matchBodyBytes = async (
   request: Request,
   expect: Uint8Array<ArrayBuffer> | ((req: Uint8Array<ArrayBuffer>) => boolean | HttpResponse<any>)

--- a/packages/test/mswHelpers/headers.ts
+++ b/packages/test/mswHelpers/headers.ts
@@ -1,5 +1,11 @@
 import { HttpResponse } from "msw";
 
+/**
+ * Matches the request's headers against `expect`, or defers to `expect` when it is a predicate.
+ *
+ * The request must carry every header in `expect` with an equal value; headers present only on the request are
+ * ignored.
+ */
 export const matchHeaders = async (
   request: Request,
   expect: Headers | ((req: Headers) => Promise<boolean | HttpResponse<any>>)

--- a/packages/test/mswHelpers/index.ts
+++ b/packages/test/mswHelpers/index.ts
@@ -1,3 +1,11 @@
+/**
+ * Chainable request matchers layered over msw's `http` handlers.
+ *
+ * `http` mirrors msw's own `http` object but returns a builder that accumulates assertions on the incoming
+ * request — body, headers, path and query parameters — before delegating to the final response resolver. It lets a
+ * test say "respond this way only when the request looks like that" without hand-writing the matching logic in every
+ * handler.
+ */
 import { matchBodyBytes, matchBodyFormData, matchBodyJSON, matchBodyText } from "./body";
 import { matchHeaders } from "./headers";
 import { matchPathParams } from "./path_params";
@@ -6,6 +14,10 @@ import { matchSearchParams } from "./search_params";
 
 import { HttpRequestHandler, HttpResponse, HttpResponseResolver, RequestHandlerOptions, http as mswHTTP } from "msw";
 
+/**
+ * Builder that accumulates request matchers and turns them into a single msw handler. Obtain one through {@link http},
+ * chain any number of matchers, then call `resolve` with the response resolver to produce the handler.
+ */
 class Resolver {
   private readonly handler: HttpRequestHandler;
 
@@ -29,6 +41,11 @@ class Resolver {
     return this;
   }
 
+  /**
+   * Registers a raw matcher predicate. When `errorResponse` is given, a non-match responds with it instead of leaving
+   * the request unhandled — use it to turn a failed expectation into a visible response rather than a silent
+   * pass-through. Every typed matcher below funnels through this method.
+   */
   resolver(fn: ResolverFn, errorResponse?: HttpResponse<any>): this {
     if (errorResponse) {
       this.resolvers.push(async (args) => {
@@ -67,6 +84,10 @@ class Resolver {
     return this.resolver(async ({ request }) => matchSearchParams(request, expect, strict), errorResponse);
   }
 
+  /**
+   * Builds the msw handler. Matchers run in registration order: a `false` result leaves the request unhandled, an
+   * `HttpResponse` answers immediately, and only once every matcher passes does `resolver` produce the real response.
+   */
   resolve(resolver: HttpResponseResolver): ReturnType<typeof this.handler> {
     return this.handler(
       this.url,
@@ -90,6 +111,10 @@ class Resolver {
   }
 }
 
+/**
+ * Entry point mirroring msw's `http`, with one method per HTTP verb. Each binds a fresh matcher builder to the given
+ * URL, ready to chain matchers and finish with `.resolve()`.
+ */
 export const http = {
   all: (url: string, options?: RequestHandlerOptions) => new Resolver(mswHTTP.all).withURL(url).withOptions(options),
   head: (url: string, options?: RequestHandlerOptions) => new Resolver(mswHTTP.head).withURL(url).withOptions(options),

--- a/packages/test/mswHelpers/path_params.ts
+++ b/packages/test/mswHelpers/path_params.ts
@@ -1,6 +1,12 @@
 import { isEqual } from "lodash-es";
 import { HttpResponse, PathParams } from "msw";
 
+/**
+ * Matches the route's path parameters against `expect`, or defers to `expect` when it is a predicate.
+ *
+ * Every parameter in `expect` must equal the resolved parameter of the same name; parameters present only on the
+ * route are ignored.
+ */
 export const matchPathParams = async (
   params: PathParams,
   expect: PathParams | ((req: PathParams) => Promise<boolean | HttpResponse<any>>)

--- a/packages/test/mswHelpers/resolver.ts
+++ b/packages/test/mswHelpers/resolver.ts
@@ -1,3 +1,10 @@
 import { HttpResponse, HttpResponseResolver } from "msw";
 
+/**
+ * A predicate run against an incoming request before its handler responds.
+ *
+ * The result drives a three-way decision: `false` leaves the request unhandled so it falls through to any
+ * other handler, `true` accepts it and moves on to the next matcher, and returning an `HttpResponse`
+ * short-circuits the chain to answer immediately — typically to surface a failed expectation.
+ */
 export type ResolverFn = (...args: Parameters<HttpResponseResolver>) => Promise<boolean | HttpResponse<any>>;

--- a/packages/test/mswHelpers/search_params.ts
+++ b/packages/test/mswHelpers/search_params.ts
@@ -1,5 +1,11 @@
 import { HttpResponse } from "msw";
 
+/**
+ * Matches the request URL's query parameters against `expect`, or defers to `expect` when it is a predicate.
+ *
+ * Every parameter in `expect` must be present with matching values, compared order-insensitively for repeated keys.
+ * By default extra query parameters are allowed; pass `strict` to also reject any parameter absent from `expect`.
+ */
 export const matchSearchParams = async (
   request: Request,
   expect: URLSearchParams | ((req: URLSearchParams) => Promise<boolean | HttpResponse<any>>),


### PR DESCRIPTION
## Summary

Sweeps in-code comments and the project docs (README/CONTRIBUTING) against the sharpened documentation contract: **rationale over restatement**, plain voice, comments paced as navigation. Removes copy-pasted spec text in favor of concise prose plus the authoritative link, adds missing docs on exported symbols, and corrects claims that had drifted from the code.

## Scope

Comments and documentation only — **no code changed** (verified: code tokens are identical after ignoring comments and whitespace across every `.go`/`.ts`/`.proto` file). Excluded: `.github/**` (managed by `a-novel repo update`), `builds/**` (deployment infra), generated/test files, `CODE_OF_CONDUCT`/`LICENSE`.

## Test plan

- [x] Repo formatter is a no-op after the sweep
- [x] Comment-only gate passes
- [ ] CI green