### PR TITLE
fix(test): compare headers via the Headers API so the matcher can reject

### DIFF
--- a/packages/test/mswHelpers/headers.test.ts
+++ b/packages/test/mswHelpers/headers.test.ts
@@ -1,0 +1,79 @@
+import { matchHeaders } from "./headers";
+
+import { describe, expect, it } from "vitest";
+
+const request = (headers: Record<string, string>) => new Request("https://example.com", { headers });
+
+describe("matchHeaders", () => {
+  it("matches when every expected header is present with an equal value", async () => {
+    const got = await matchHeaders(
+      request({ authorization: "Bearer token", "x-trace": "abc" }),
+      new Headers({ authorization: "Bearer token", "x-trace": "abc" })
+    );
+
+    expect(got).toBe(true);
+  });
+
+  // The three rejection cases below are the ones that pass vacuously when the matcher iterates the
+  // Headers instance with Object.entries: the loop body never runs, so it can only ever return true.
+  it("rejects a header whose value differs", async () => {
+    const got = await matchHeaders(
+      request({ authorization: "Bearer wrong" }),
+      new Headers({ authorization: "Bearer token" })
+    );
+
+    expect(got).toBe(false);
+  });
+
+  it("rejects a request missing an expected header entirely", async () => {
+    const got = await matchHeaders(request({ "x-trace": "abc" }), new Headers({ authorization: "Bearer token" }));
+
+    expect(got).toBe(false);
+  });
+
+  it("rejects when only some of the expected headers match", async () => {
+    const got = await matchHeaders(
+      request({ authorization: "Bearer token", "x-trace": "wrong" }),
+      new Headers({ authorization: "Bearer token", "x-trace": "abc" })
+    );
+
+    expect(got).toBe(false);
+  });
+
+  it("ignores headers present only on the request", async () => {
+    const got = await matchHeaders(
+      request({ authorization: "Bearer token", "x-extra": "ignored" }),
+      new Headers({ authorization: "Bearer token" })
+    );
+
+    expect(got).toBe(true);
+  });
+
+  // Headers lowercases its keys on both sides, so an expectation written in any casing still resolves.
+  it("compares header names case-insensitively", async () => {
+    const got = await matchHeaders(
+      request({ authorization: "Bearer token" }),
+      new Headers({ AUTHORIZATION: "Bearer token" })
+    );
+
+    expect(got).toBe(true);
+  });
+
+  it("defers to a predicate and forwards the request headers", async () => {
+    const got = await matchHeaders(
+      request({ authorization: "Bearer token" }),
+      async (req) => req.get("authorization") === "Bearer token"
+    );
+
+    expect(got).toBe(true);
+  });
+
+  it("returns the predicate's rejection", async () => {
+    const got = await matchHeaders(
+      request({ authorization: "Bearer wrong" }),
+      async (req) => req.get("authorization") === "Bearer token"
+    );
+
+    expect(got).toBe(false);
+  });
+});

--- a/packages/test/mswHelpers/headers.ts
+++ b/packages/test/mswHelpers/headers.ts
@@ -14,7 +14,10 @@ export const matchHeaders = async (
     return (expect as (req: Headers) => Promise<boolean | HttpResponse<any>>)(request.headers);
   }
 
-  for (const [key, value] of Object.entries(expect)) {
+  // Headers keeps its data in internal slots rather than own enumerable properties, so Object.entries
+  // on it yields an empty list and every comparison would be skipped — making the matcher pass for any
+  // request. Iterate the Headers API instead, as matchSearchParams does for URLSearchParams.
+  for (const [key, value] of expect.entries()) {
     if (request.headers.get(key) !== value) {
       return false;
     }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,13 +24,19 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "json", "html", "lcov"],
       reportsDirectory: "coverage",
-      include: ["packages/browser/**/*.{ts,tsx}"],
-      exclude: ["packages/browser/dist"],
+      include: ["packages/browser/**/*.{ts,tsx}", "packages/test/**/*.{ts,tsx}"],
+      exclude: ["packages/browser/dist", "packages/test/dist"],
       allowExternal: true,
     },
+    // Every package holding tests needs an entry here: vitest only collects from registered projects,
+    // so a package omitted from this list reports no failures because it is never run at all.
     projects: [
       {
         root: "packages/browser",
+        extends: true,
+      },
+      {
+        root: "packages/test",
         extends: true,
       },
     ],


### PR DESCRIPTION
## Summary

- `matchHeaders` returned `true` for every request. `Object.entries` on a `Headers` instance yields
  `[]` — `Headers` keeps its data in internal slots, not own enumerable properties — so the comparison
  loop never executed. Any consumer test asserting on request headers was passing vacuously, and a
  regression that dropped an `Authorization` header entirely would still go green.
- Registers `packages/test` as a vitest project. It is not incidental: vitest only collects from
  registered projects, so the package had no tests because none could have run. Leaving that out would
  have added a test file that never executes — the same class of defect as the bug being fixed.

The sibling matchers are why this survived review: `search_params.ts` uses `expect.keys()` on a
`URLSearchParams` and `path_params.ts` uses `Object.entries()` on a **plain object**, both correct.
`headers.ts` copied the plain-object idiom onto a Web IDL class, where it silently degrades instead of
failing.

Closes #633

## Test plan

- [x] The three rejection cases fail against the previous implementation (verified by reverting)
- [x] `pnpm test` passes — 28 tests, 5 files
- [x] `pnpm lint` passes
- [ ] CI green